### PR TITLE
Reverse direction Keyboard controller

### DIFF
--- a/src/components/PlayerControllerKeyboard.jsx
+++ b/src/components/PlayerControllerKeyboard.jsx
@@ -121,6 +121,12 @@ export const PlayerControllerKeyboard = ({
     } else if (rightPressed && currentSpeed > 0) {
       steeringAngle = -currentSteeringSpeed;
       targetXPosition = camMaxOffset;
+    } else if (rightPressed && currentSpeed < 0) {
+      steeringAngle = currentSteeringSpeed;
+      targetXPosition = -camMaxOffset;
+    } else if (leftPressed && currentSpeed < 0) {
+      steeringAngle = -currentSteeringSpeed;
+      targetXPosition = camMaxOffset;
     } else {
       steeringAngle = 0;
       targetXPosition = 0;
@@ -170,13 +176,24 @@ export const PlayerControllerKeyboard = ({
     }
 
     // REVERSING
-    if (downPressed && currentSpeed < -maxSpeed) {
+    if (downPressed) {
+      if (currentSteeringSpeed < MaxSteeringSpeed) {
+        setCurrentSteeringSpeed(
+          Math.min(
+            currentSteeringSpeed + 0.0001 * delta * 144,
+            MaxSteeringSpeed
+          )
+        );
+      }
+    }
+
+    if (downPressed && currentSpeed <= 0) {
       setCurrentSpeed(
         Math.max(currentSpeed - acceleration * delta * 144, -maxSpeed)
       );
     }
     // DECELERATING
-    else if (!upPressed && !downPressed) {
+    else if (!upPressed) {
       if (currentSteeringSpeed > 0) {
         setCurrentSteeringSpeed(
           Math.max(currentSteeringSpeed - 0.00005 * delta * 144, 0)


### PR DESCRIPTION
Before playercontrollerkeyboard reverse didn't work, now it work.
I haven't checked for the other controllers but if it seems like a good observation I can adjust on the other controllers too.