### PR TITLE
fix reverse on gamepad and mouse controller

### DIFF
--- a/src/components/PlayerController.jsx
+++ b/src/components/PlayerController.jsx
@@ -121,6 +121,12 @@ export const PlayerController = ({
     } else if (rightPressed && currentSpeed > 0) {
       steeringAngle = -currentSteeringSpeed;
       targetXPosition = camMaxOffset;
+    } else if (rightPressed && currentSpeed < 0) {
+      steeringAngle = currentSteeringSpeed;
+      targetXPosition = -camMaxOffset;
+    } else if (leftPressed && currentSpeed < 0) {
+      steeringAngle = -currentSteeringSpeed;
+      targetXPosition = camMaxOffset;
     } else {
       steeringAngle = 0;
       targetXPosition = 0;
@@ -182,13 +188,24 @@ export const PlayerController = ({
     }
 
     // REVERSING
-    if (downPressed && currentSpeed < -maxSpeed) {
+    if (downPressed) {
+      if (currentSteeringSpeed < MaxSteeringSpeed) {
+        setCurrentSteeringSpeed(
+          Math.min(
+            currentSteeringSpeed + 0.0001 * delta * 144,
+            MaxSteeringSpeed
+          )
+        );
+      }
+    }
+
+    if (downPressed && currentSpeed <= 0) {
       setCurrentSpeed(
         Math.max(currentSpeed - acceleration * delta * 144, -maxSpeed)
       );
     }
     // DECELERATING
-    else if (!upPressed && !downPressed) {
+    else if (!upPressed) {
       if (currentSteeringSpeed > 0) {
         setCurrentSteeringSpeed(
           Math.max(currentSteeringSpeed - 0.00005 * delta * 144, 0)

--- a/src/components/PlayerControllerGamepad.jsx
+++ b/src/components/PlayerControllerGamepad.jsx
@@ -165,13 +165,24 @@ export const PlayerControllerGamepad = ({
     }
 
     // REVERSING
-    if (buttonB && currentSpeed < -maxSpeed) {
+    if (buttonB) {
+      if (currentSteeringSpeed < MaxSteeringSpeed) {
+        setCurrentSteeringSpeed(
+          Math.min(
+            currentSteeringSpeed + 0.0001 * delta * 144,
+            MaxSteeringSpeed
+          )
+        );
+      }
+    }
+
+    if (buttonB && currentSpeed <= 0) {
       setCurrentSpeed(
         Math.max(currentSpeed - acceleration * delta * 144, -maxSpeed)
       );
     }
     // DECELERATING
-    else if (!buttonA && !buttonB) {
+    else if (!buttonA) {
       if (currentSteeringSpeed > 0) {
         setCurrentSteeringSpeed(
           Math.max(currentSteeringSpeed - 0.00005 * delta * 144, 0)


### PR DESCRIPTION
As promised I solved the reverse problem also on gamepad and mouse keyboard. Tested.
The gamepad is not very intuitive and the rotation in relation to the direction when going backwards