### PR TITLE
Disabled User Select

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@
 #root {
   width: 100vw;
   height: 100vh;
+  user-select: none;
 }
 
 * {


### PR DESCRIPTION
# Disabled User Select
Disabled the user select option in the CSS in order to prevent the user from selecting text/images. As it can happened accidentally quite easily (especially on PC), and there's no need to allow the user to select text nor images in the context of the game.

Here's an example of how the game looks if the user accidentally selects he text on the home screen:
![Screenshot_1](https://github.com/Lunakepio/Mario-Kart-3.js/assets/85199046/2ac7f9d5-74c7-43e7-9b03-5065fa8ea20b)
